### PR TITLE
feat: allow overriding sitemap crumb label per page

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,11 +263,17 @@ export const AboutUs = ({ pageContext, location, crumbLabel }) => {
     breadcrumb: { crumbs },
   } = pageContext;
 
+  const customCrumbLabel = location.pathname.toLowerCase();
+
   return (
     <div>
       <Header>
         <main>
-          <SitemapCrumbs crumbs={crumbs} crumbSeparator=" - " />
+          <SitemapCrumbs
+            crumbs={crumbs}
+            crumbSeparator=" - "
+            crumbLabel={customCrumbLabel}
+          />
           ...
         </main>
       </Header>
@@ -286,6 +292,7 @@ instead of to individual crumbs, as with `Click Tracking`.
 | crumbs            | array  | Array of crumbs return from pageContext  | n/a                             | required |
 | title             | string | Title proceeding the breadcrumbs         | `"Breadcrumbs: "`, `">>>"`      | optional |
 | crumbSeparator    | string | Separator between each breadcrumb        | `" / "`                         | optional |
+| crumbLabel        | string | Override crumb label from xml path       | `"About Us"`                    | optional |
 | crumbWrapperStyle | object | CSS object applied to breadcrumb wrapper | `{ border: '1px solid white' }` | optional |
 | crumbStyle        | object | CSS object applied to all the crumbs     | `{ color: 'orange' }`           | optional |
 | crumbActiveStyle  | object | CSS object applied to crumb when active  | `{ color: 'cornflowerblue'}`    | optional |

--- a/src/components/SitemapCrumbs.js
+++ b/src/components/SitemapCrumbs.js
@@ -9,6 +9,7 @@ const SitemapCrumb = ({
   crumbActiveStyle,
   crumbStyle,
   crumbs: siteCrumbs,
+  crumbLabel: crumbLabelOverride = null,
   ...rest
 }) => {
   return (
@@ -31,7 +32,9 @@ const SitemapCrumb = ({
               }}
               {...rest}
             >
-              {c.crumbLabel}
+              {crumbLabelOverride && i === siteCrumbs.length - 1
+                ? crumbLabelOverride
+                : c.crumbLabel}
             </Link>
             <span style={{ fontSize: '16pt', ...crumbStyle }}>
               {crumbSeparator}


### PR DESCRIPTION
Allow overriding (per page) a SitemapCrumbs label.  While this isn't totally dynamic it allows you to pass what you want the label to be.  You can pull location from props in a gatsby page, and then manipulate it however you like, and pass it as the overriding `crumbLabel` prop to `SitemapCrumbs`.  I will continue to look into something a little more dynamic, but it is hard to automatically know what the page crumb should be just based on the path from someones sitemap.xml.  I hopefully can find a way to provide a page value (custom label) and then we can override the `gatsby-plugin-sitemap` query and pull extra data into the sitemap.xml that is generated.  PR's welcome for such a thing! 

```
const AboutUs = ({ pageContext, location, crumbLabel }) => {
  const {
    breadcrumb: { crumbs },
  } = pageContext

const { pathname } = location;

const newLabel = pathname.slice(0, -1);   // manipulate however you please 

  return (
    <div>
      <div>
        <main>
          <SitemapCrumbs
            crumbs={crumbs}
            crumbSeparator=" - "
            crumbStyle={{ color: "#666" }}
            crumbActiveStyle={{ color: "#666" }}
            crumbLabel={newLabel}
          />
        </main>
      </div>
    </div>
  )
}

AboutUs.description = "testtesttest"

export default AboutUs
```
