### PR TITLE
API Redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ npm install gatsby-plugin-breadcrumb
 
 CodeSandbox.io [Demo](https://codesandbox.io/s/50o4zwm91l)
 
+# \* Warning: `<SitemapCrumbs />` component has been deprecated and replaced by the `<Breadcrumb />`
+
+The `<SitemapCrumbs />` component has been deprecated and will be removed in
+version 6. This will simplify the API so you always use the `<Breadcrumb />`
+component, reguardless of the way you are using `gatsby-plugin-breadcrumb`
+(Click Tracking or AutoGen (new Sitemap method)). Please update using the
+`<Breadcrumb />` component if you are currently using the `<SitemapCrumbs />`
+component or AutoGen method method of populating your breadcrumbs.
+
 ## Usage
 
 There are three ways to use `gatsby-plugin-breadcrumb` to add breadcrumbs to
@@ -49,18 +58,18 @@ your Gatsby site:
     - [Breadcrumb with Layout component](#click-tracking-layout-component-example)
     - [Breadcrumb with default crumb](#click-tracking-default-crumb-example)
 
-- `Sitemap`: Sitemap will use a sitemap xml file (gererated using
-  `gatsby-plugin-sitemap`) to create the breadcrumb.
+- `AutoGen` (Auto Generated): AutoGen will generate breadcrumbs for each page
+  and inject them into pages `pageContext` prop under the `breadcrumb` property.
 
   - Add the plugin `gatsby-plugin-remove-trailing-slashes`
-  - Add the plugin `gatsby-plugin-breadcrumb` and define the `useSitemap` plugin
+  - Add the plugin `gatsby-plugin-breadcrumb` and define the `useAutoGen` plugin
     option to `true`
   - Get `crumbs` array from `breadcrumb` object in `pageContext`
-  - Import and use the `<SitemapCrumbs>` component, passing the required props
-    on pages you wish to see the breadcrumb
+  - Import and use the `<AutoGenCrumb>` component, passing the required props on
+    pages you wish to see the breadcrumb
 
-    - [Sitemap example](#sitemap-example)
-    - [SitemapCrumbs component props](#sitemapcrumbs-props-for-sitemap)
+    - [AutoGen example](#autogen-example)
+    - [AutoGenCrumb component props](#autogencrumb-props-for-autogen)
 
 - `useBreadcrumb`: The `useBreadcrumb` hook enables you to control your own
   breadcrumbs, by calling `useBreadcrumb` and passing the required object
@@ -109,7 +118,7 @@ your Gatsby site:
 import React from 'react'
 import { Breadcrumb } from 'gatsby-plugin-breadcrumb'
 
-export const AboutUs = ({ location, data: { allPageJson } }) => {
+export const AboutUs = ({ location }) => {
   ...
   return(
     <div>
@@ -125,7 +134,7 @@ export const AboutUs = ({ location, data: { allPageJson } }) => {
 The `<Breadcrumb>` component provides default breadcrumbs, while also allowing
 you to customize those breadcrumbs if you wish.
 
-### Breadcrumb Props
+### Breadcrumb Props with `Click Tracking`
 
 | prop              | type   | description                                     | examples                                                        | required | useClassNames disables |
 | ----------------- | ------ | ----------------------------------------------- | --------------------------------------------------------------- | -------- | ---------------------- |
@@ -151,7 +160,7 @@ import React from 'react'
 import Layout from './layout'
 ...
 
-export const AboutUs = ({location}) => {
+export const AboutUs = ({ location }) => {
   return (
     <Layout location={location} crumbLabel="About Us" >
       ...
@@ -222,7 +231,7 @@ using all available options.
   },
 ```
 
-### Click Tracking `useClassNames` example
+### `useClassNames` example with `Click Tracking`
 
 By default `gatsby-plugin-breadcrumb` uses CSS in JS. Allowing you to pass
 styles as props to the `Breadcrumb` component. You can disable this behavior
@@ -265,13 +274,14 @@ component:
 }
 ```
 
-## `Sitemap` example
+## `AutoGen` example
 
-`Sitemap` used to rely on `gatsby-plugin-sitemap`, which creates a sitmap XML
-file in the `/public` folder of your site at the end of the site build. This
-caused problems when deploying to services like Netlify, as the XML file was not
-created when we needed to try to read from it, causing the build to fail. Now
-`Sitemap` generates the breadcrumbs as pages are created.
+`AutoGen` (Auto Generated, previously `Sitemap`) used to rely on
+`gatsby-plugin-sitemap`, which creates a sitmap XML file in the `/public` folder
+of your site at the end of the site build. This caused problems when deploying
+to services like Netlify, as the XML file was not created when we needed to try
+to read from it, causing the build to fail. Now `AutoGen` generates the
+breadcrumbs as pages are created.
 
 Install `gatsby-plugin-remove-trailing-slashes`
 
@@ -302,10 +312,10 @@ Add the following to your gatsby-config
     {
       resolve: `gatsby-plugin-breadcrumb`,
       options: {
-        // useSitemap: required 'true' to use sitemap
-        useSitemap: true,
-        // sitemapHomeLabel: optional 'Home' is default
-        sitemapHomeLabel: `Root`,
+        // useAutoGen: required 'true' to use autogen
+        useAutoGen: true,
+        // autoGenHomeLabel: optional 'Home' is default
+        autoGenHomeLabel: `Root`,
         // exlude: optional, include to overwrite default excluded pages
         exclude: [
           `/dev-404-page`,
@@ -314,22 +324,22 @@ Add the following to your gatsby-config
           `/offline-plugin-app-shell-fallback`,
         ],
         // optional: switch to className styling
-        // see SitemapCrumbs useClassNames example below
+        // see AutoGenCrumb useClassNames example below
         useClassNames: true,
      },
   ]
 }
 ```
 
-SitemapCrumbs component example
+### `Breadcrumb` component example with `AutoGen`
 
 `/pages/about-us.js`
 
 ```jsx
 import React from 'react'
-import { SitemapCrumbs } from 'gatsby-plugin-breadcrumb'
+import { Breadcrumb } from 'gatsby-plugin-breadcrumb'
 
-export const AboutUs = ({ pageContext, location, crumbLabel }) => {
+export const AboutUs = ({ pageContext, location }) => {
   const {
     breadcrumb: { crumbs },
   } = pageContext
@@ -341,7 +351,7 @@ export const AboutUs = ({ pageContext, location, crumbLabel }) => {
     <div>
       <Header>
         <main>
-          <SitemapCrumbs
+          <Breadcrumb
             crumbs={crumbs}
             crumbSeparator=" - "
             crumbLabel={customCrumbLabel}
@@ -354,7 +364,7 @@ export const AboutUs = ({ pageContext, location, crumbLabel }) => {
 }
 ```
 
-### SitemapCrumbs Props
+### `Breadcrumb` Props with `AutoGen`
 
 `Note`: The crumbStyle prop will apply to all the crumbs in the breadcrumb
 instead of to individual crumbs, as with `Click Tracking`.
@@ -370,14 +380,14 @@ instead of to individual crumbs, as with `Click Tracking`.
 | crumbActiveStyle  | object | CSS object applied to crumb when active  | `{ color: 'cornflowerblue'}`    | optional | x                      |
 | ...rest           | object | Any other props you may pass             | n/a: spread accross crumb Link  | optional |                        |
 
-### SitemapCrumbs `useClassNames` example
+### `useClassNames` example with `AutoGen`
 
 By default `gatsby-plugin-breadcrumb` uses CSS in JS. Allowing you to pass
-styles as props to the `SitemapCrumbs` component. You can disable this behavior
+styles as props to the `Breadcrumb` component. You can disable this behavior
 (and default styles) by passing the `useClassNames: true` plugin option. This
 will disable any default styling of the component and allow you to use CSS to
-style your breadcrumbs. Here is a list of the classes used with the
-`SitemapCrumbs` component:
+style your breadcrumbs. Here is a list of the classes used with the `Breadcrumb`
+component:
 
 | class                      | description                                    |
 | -------------------------- | ---------------------------------------------- |
@@ -399,7 +409,7 @@ style your breadcrumbs. Here is a list of the classes used with the
     {
       resolve: `gatsby-plugin-breadcrumb`,
       options: {
-        useSitemap: true,
+        useAutoGen: true,
         useClassNames: true,
      },
   ]
@@ -470,10 +480,6 @@ be mentioned here submit a PR, or just let us know!
 
 - In your `gatsby-config.js` option `siteMetaData.siteUrl` be sure to remove any
   trailing slashes
-- When using `Sitemap` breadcrumbs you must add a page then run
-  `gatsby build && gatsby serve` before trying to access the breadcrumb object
-  from pageContext. The breadcrumb object builds off the sitemap generated by
-  this command. If you try to access the object before running it, it will not
-  exist for the new page
+
 - The `<Link>'s` throughout your site need to have `to` properties that match
   your breadcrumb `to` properties for activeStyles to be applied.

--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ import MyCustomBreadcrumb from './my-custom-breadcrumb'
 import { useBreadcrumb } from 'gatsby-plugin-breadcrumb'
 
 export const AboutUs = ({ location }) => {
-  const { crumbs, updateCrumbs } = useBreadcrumb({
+  const { crumbs } = useBreadcrumb({
     location,
     crumbLabel: 'About Us',
     crumbSeparator: ' / ',
@@ -448,12 +448,11 @@ The `useBreadcrumb` hook takes an object with the following properties:
 
 `useBreadcrumb` returns the following:
 
-| value         | type     | description                                                                                                             |
-| ------------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
-| crumbs        | array    | Array of the current breadcrumbs                                                                                        |
-| updateCrumbs  | function | Function to enable you to manually update crumbs (The hook should handle this, only use if you know what you are doing) |
-| useClassNames | bool     | Value of the useClassNames plugin option (default: false)                                                               |
-| useAutoGen    | bool     | Value of the useAutoGen plugin option (default: false)                                                                  |
+| value         | type  | description                                               |
+| ------------- | ----- | --------------------------------------------------------- |
+| crumbs        | array | Array of the current breadcrumbs                          |
+| useClassNames | bool  | Value of the useClassNames plugin option (default: false) |
+| useAutoGen    | bool  | Value of the useAutoGen plugin option (default: false)    |
 
 The `useBreadcrumb` hook will determine if it needs to add, remove, or do
 nothing with the breadcrumbs based on the location you pass. You only need to

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 ### Breadcrumbs for Gatsby
 
-Add Breadcrumbs to your Gatsby Site!
-
 - [Installation](https://github.com/sbardian/gatsby-plugin-breadcrumb#installation)
 - [Usage](https://github.com/sbardian/gatsby-plugin-breadcrumb#usage)
 - [Gotchas](https://github.com/sbardian/gatsby-plugin-breadcrumb#gotchas)
@@ -27,59 +25,65 @@ or
 npm install gatsby-plugin-breadcrumb
 ```
 
-## \* Warning: `<SitemapCrumbs />` component has been deprecated and replaced by the `<Breadcrumb />` component
-
-The `<SitemapCrumbs />` component has been deprecated and will be removed in
-version 7. This will simplify the API so you always use the `<Breadcrumb />`
-component, reguardless of the way you are using `gatsby-plugin-breadcrumb`
-(Click Tracking or AutoGen (new Sitemap method)). Please update using the
-`<Breadcrumb />` component if you are currently using the `<SitemapCrumbs />`
-component or AutoGen method method of populating your breadcrumbs.
-
 ## Usage
 
-There are three ways to use `gatsby-plugin-breadcrumb` to add breadcrumbs to
-your Gatsby site:
+There are two ways to use `gatsby-plugin-breadcrumb` to add breadcrumbs to your
+Gatsby site: Click Tracking and AutoGen.
 
-- `Click Tracking`: Click tracking creates a breadcrumb of out of the path taken
-  (clicked) by the user.
+### Click Tracking
+
+Click tracking creates a breadcrumb of out of the path taken (clicked) by the
+user. The two ways to use click tracking are:
+
+- Using the `<Breadcrumb />` component:
 
   - Add the plugin `gatsby-plugin-breadcrumb` to your `gatsby-config.js`
-  - Import and use the `<Breadcrumb />` component, passing the required props on
-    pages you wish to see the breadcrumb.
+  - Import and use the `<Breadcrumb />` component, passing the required props,
+    on pages you wish to see the breadcrumb.
 
     - [Click Tracking example](#click-tracking-example)
-    - [Breadcrumb props](#breadcrumb-props)
+    - [Breadcrumb props](#breadcrumb-props-with-click-tracking)
     - [Breadcrumb with Layout component](#click-tracking-layout-component-example)
-    - [Breadcrumb with default crumb](#click-tracking-default-crumb-example)
+    - [Breadcrumb with default crumb](#click-tracking-defaultcrumb-example)
+    - [Breadcrumb using classes](#useclassnames-example-with-click-tracking)
 
-- `AutoGen` (Auto Generated): AutoGen will generate breadcrumbs for each page
-  and inject them into pages `pageContext` prop under the `breadcrumb` property.
+- Using the `useBreadcrumb` hook: The `useBreadcrumb` hook enables you to
+  control your own breadcrumbs, by calling `useBreadcrumb` and passing the
+  required object properties. Using the hook enables you to pass the breadcrumbs
+  to your own custom Breadcrumb component, but still take advantage of
+  `gatsby-plugin-breadcrumbs` click tracking logic.
 
-  - Add the plugin `gatsby-plugin-breadcrumb` to your `gatsby-config.js` and
-    define the `useAutoGen` plugin option to `true`
-  - Get `crumbs` array from `breadcrumb` object in `pageContext`
-  - Import and use the `<Breadcrumb />` component, passing the required props on
-    pages you wish to see the breadcrumb
-
-    - [AutoGen example](#autogen-example)
-    - [AutoGenCrumb component props](#autogencrumb-props-for-autogen)
-
-- `useBreadcrumb`: The `useBreadcrumb` hook enables you to control your own
-  breadcrumbs, by calling `useBreadcrumb` and passing the required object
-  properties
-
-  - Add the plugin `gatsby-plugin-breadcrumb`
-  - Import and use the `useBreadcrumb` hook, passing the required props object
+  - Add the plugin `gatsby-plugin-breadcrumb` to your `gatsby-config.js`
+  - Import and use the `useBreadcrumb` hook, passing the required object
+    properties.
 
     - [useBreadcrumb example](#usebreadcrumb-example)
-    - [useBreadcrumb props/returns](#useBreadcrumb-props-and-returns)
+    - [useBreadcrumb props/returns](#usebreadcrumb-arguments-and-returns)
 
-## `Click Tracking` example:
+### AutoGen
+
+AutoGen (Auto Generated) will generate breadcrumbs for each page and inject them
+into Gatsby page `pageContext` prop under the `breadcrumb` property.
+
+- Add the plugin `gatsby-plugin-breadcrumb` to your `gatsby-config.js` and
+  define the `useAutoGen` plugin option to `true`
+- Get `crumbs` array from `breadcrumb` object in `pageContext`
+- Import and use the `<Breadcrumb />` component, passing the required props on
+  pages you wish to see the breadcrumb
+
+  - [AutoGen example](#autogen-example)
+  - [Breadcrumb props](#breadcrumb-props-with-autogen)
+  - [Breadcrumb using classes](#useclassnames-example-with-autogen)
+
+> Use of the `<Breadcrumb />` component is not a requirement. If you want to
+> create your own breadcrumb component, and pass it the breadcrumb data from
+> `pageContext`, this is always an option.
+
+## Click Tracking example:
 
 CodeSandbox.io [Demo](https://codesandbox.io/s/50o4zwm91l)
 
-`gatsby-config.js`
+gatsby-config.js
 
 ```javascript
 {
@@ -108,7 +112,7 @@ CodeSandbox.io [Demo](https://codesandbox.io/s/50o4zwm91l)
 }
 ```
 
-`/pages/aboutus.js`
+/pages/aboutus.js
 
 ```jsx
 import React from 'react'
@@ -125,12 +129,12 @@ export const AboutUs = ({ location }) => {
 }
 ```
 
-### Breadcrumb component with `Click Tracking`
+### Breadcrumb component with Click Tracking
 
 The `<Breadcrumb />` component provides default breadcrumbs, while also allowing
 you to customize those breadcrumbs if you wish.
 
-### Breadcrumb Props with `Click Tracking`
+### Breadcrumb Props with Click Tracking
 
 | prop              | type   | description                                     | examples                                                        | required | useClassNames disables |
 | ----------------- | ------ | ----------------------------------------------- | --------------------------------------------------------------- | -------- | ---------------------- |
@@ -142,16 +146,16 @@ you to customize those breadcrumbs if you wish.
 | crumbStyle        | object | CSS object applied to the current crumb         | `{ color: 'orange' }`                                           | optional | x                      |
 | crumbActiveStyle  | object | CSS object applied to current crumb when active | `{ color: 'cornflowerblue'}`                                    | optional | x                      |
 
-### Other `Click Tracking` options
+### Other Click Tracking options
 
 Instead of adding the `<Breadcrumb />` component to every page, another option
 would be to add it to a layout component.
 
-### `Click Tracking` Layout component example
+### Click Tracking Layout component example
 
 CodeSandbox.io [Demo](https://codesandbox.io/s/breadcrumb-with-layout-ce0rp)
 
-`/pages/aboutus.js`
+/pages/aboutus.js
 
 ```jsx
 import React from 'react'
@@ -167,7 +171,7 @@ export const AboutUs = ({ location }) => {
 }
 ```
 
-`/pages/contact.js`
+/pages/contact.js
 
 ```jsx
 import React from 'react'
@@ -182,7 +186,7 @@ export const Contact = ({location}) => {
 }
 ```
 
-`/components/layout.js`
+/components/layout.js
 
 ```jsx
 import React from 'react'
@@ -202,25 +206,28 @@ export const Layout = ({location, crumbLabel}) => {
 }
 ```
 
-### Click Tracking `defaultCrumb` example
+### Click Tracking defaultCrumb example
 
-While using the `Click Tracking` option with the `<Breadcrumb />` component, if
-a user goes directly to a page, your breadcrumb will start with that page. You
-may want to always provide a default or `Home` breadcrumb. You can do this by
-adding options to the plugin. We must structure the `default` breadcrumb we
-provide in the plugin options in a way our context is expecting, see below for
-an example using all available options.
+While using the Click Tracking option with the `<Breadcrumb />` component, if a
+user goes directly to a page, your breadcrumb will start with that page. You may
+want to always provide a default or "Home" breadcrumb. You can do this by adding
+a `defaultCrumb` plugin option. We must structure the `defaultCrumb` breadcrumb
+we provide in a way our context is expecting, see below for an example using all
+available options.
 
 ```javascript
   {
     resolve: `gatsby-plugin-breadcrumb`,
     options: {
       defaultCrumb: {
+        // location: required and must include the following properties
         location: {
           state: { crumbClicked: false },
           pathname: "/",
         },
+        // crumbLabel: required label for the default crumb
         crumbLabel: "Home",
+        // all other properties optional
         crumbSeparator: " / ",
         crumbStyle: { color: "#666" },
         crumbActiveStyle: { color: "orange" },
@@ -229,14 +236,14 @@ an example using all available options.
   },
 ```
 
-### `useClassNames` example with `Click Tracking`
+### useClassNames example with Click Tracking
 
 By default `gatsby-plugin-breadcrumb` uses CSS in JS. Allowing you to pass
 styles as props to the `Breadcrumb` component. You can disable this behavior
 (and default styles) by passing the `useClassNames: true` plugin option. This
 will disable any default styling of the component and allow you to use CSS to
-style your breadcrumbs. Here is a list of the classes used with the `Breadcrumb`
-component:
+style your breadcrumbs. Here is a list of the classes used with the
+`<Breadcrumb />` component:
 
 | class                      | description                                    |
 | -------------------------- | ---------------------------------------------- |
@@ -245,7 +252,7 @@ component:
 | `breadcrumb__link`         | Applied to the link of the breadcrumb          |
 | `breadcrumb__link__active` | Applied to the link when active (current link) |
 
-`gatsby-config.js` example
+gatsby-config.js
 
 ```javascript
 {
@@ -265,27 +272,84 @@ component:
           crumbLabel: "Home",
           crumbSeparator: " - ",
       },
+        // required to enable classNames
         useClassNames: true,
      },
   ]
 }
 ```
 
-## `AutoGen` example
+### useBreadcrumb example:
+
+gatsby-config.js
+
+```javascript
+{
+  plugins: [
+    `gatsby-plugin-breadcrumb`,
+  ],
+}
+```
+
+/pages/about-us.js
+
+```jsx
+import React from 'react'
+import MyCustomBreadcrumb from './my-custom-breadcrumb'
+import { useBreadcrumb } from 'gatsby-plugin-breadcrumb'
+
+export const AboutUs = ({ location }) => {
+  const { crumbs } = useBreadcrumb({
+    location,
+    crumbLabel: 'About Us',
+    crumbSeparator: ' / ',
+  })
+  return (
+    <div>
+      <MyCustomBreadcrumb crumbs={crumbs} />
+      ...
+    </div>
+  )
+}
+```
+
+### useBreadcrumb arguments and returns
+
+The `useBreadcrumb` hook takes an object with the following properties:
+
+| prop             | type   | description                                     | examples                                                        | required |
+| ---------------- | ------ | ----------------------------------------------- | --------------------------------------------------------------- | -------- |
+| location         | object | Reach Router location prop                      | See Reach Router location prop, passed by Gatsby to every page. | required |
+| crumbLabel       | string | Name for the breadcrumb                         | `"About Us"`                                                    | required |
+| crumbSeparator   | string | Separator between each breadcrumb               | `" / "`                                                         | optional |
+| crumbStyle       | object | CSS object applied to the current crumb         | `{ color: 'orange' }`                                           | optional |
+| crumbActiveStyle | object | CSS object applied to current crumb when active | `{ color: 'cornflowerblue'}`                                    | optional |
+
+`useBreadcrumb` returns the following:
+
+| value  | type  | description                      |
+| ------ | ----- | -------------------------------- |
+| crumbs | array | Array of the current breadcrumbs |
+
+The `useBreadcrumb` hook will determine if it needs to add, remove, or do
+nothing with the breadcrumbs based on the location you pass. You only need to
+pass it the required props (`location`, `crumbLabel`).
+
+## AutoGen example
 
 Codesandbox.io [Demo](https://codesandbox.io/s/auto-generated-breadcrumbs-m5p5t)
 
-`AutoGen` (Auto Generated, previously `Sitemap`) used to rely on
+AutoGen (Auto Generated, previously Sitemap) used to rely on
 `gatsby-plugin-sitemap`, which creates a sitmap XML file in the `/public` folder
 of your site at the end of the site build. This caused problems when deploying
 to services like Netlify, as the XML file was not created when we needed to try
-to read from it, causing the build to fail. Now `AutoGen` generates the
+to read from it, causing the build to fail. Now AutoGen generates the
 breadcrumbs as pages are created. We also no longer require the
 `gatsby-plugin-remove-trailing-slashes` plugin.
 
 Add the following to your gatsby-config
 
-`gatsby-config.js`
+gatsby-config.js
 
 ```javascript
 {
@@ -316,9 +380,9 @@ Add the following to your gatsby-config
 }
 ```
 
-### `Breadcrumb` component example with `AutoGen`
+### Breadcrumb component example with AutoGen
 
-`/pages/about-us.js`
+/pages/about-us.js
 
 ```jsx
 import React from 'react'
@@ -349,10 +413,10 @@ export const AboutUs = ({ pageContext, location }) => {
 }
 ```
 
-### `Breadcrumb` Props with `AutoGen`
+### Breadcrumb Props with AutoGen
 
-`Note`: The crumbStyle prop will apply to all the crumbs in the breadcrumb
-instead of to individual crumbs, as with `Click Tracking`.
+Note: The crumbStyle prop will apply to all the crumbs in the breadcrumb instead
+of to individual crumbs, as with Click Tracking.
 
 | prop              | type   | description                              | examples                        | required | useClassNames disables |
 | ----------------- | ------ | ---------------------------------------- | ------------------------------- | -------- | ---------------------- |
@@ -365,14 +429,14 @@ instead of to individual crumbs, as with `Click Tracking`.
 | crumbActiveStyle  | object | CSS object applied to crumb when active  | `{ color: 'cornflowerblue'}`    | optional | x                      |
 | ...rest           | object | Any other props you may pass             | n/a: spread accross crumb Link  | optional |                        |
 
-### `useClassNames` example with `AutoGen`
+### useClassNames example with AutoGen
 
 By default `gatsby-plugin-breadcrumb` uses CSS in JS. Allowing you to pass
 styles as props to the `Breadcrumb` component. You can disable this behavior
 (and default styles) by passing the `useClassNames: true` plugin option. This
 will disable any default styling of the component and allow you to use CSS to
-style your breadcrumbs. Here is a list of the classes used with the `Breadcrumb`
-component:
+style your breadcrumbs. Here is a list of the classes used with the
+`<Breadcrumb />` component:
 
 | class                      | description                                    |
 | -------------------------- | ---------------------------------------------- |
@@ -381,7 +445,7 @@ component:
 | `breadcrumb__link`         | Applied to the link of the breadcrumb          |
 | `breadcrumb__link__active` | Applied to the link when active (current link) |
 
-`gatsby-config.js` example
+gatsby-config.js
 
 ```javascript
 {
@@ -400,64 +464,6 @@ component:
 }
 ```
 
-## `useBreadcrumb` example:
-
-`gatsby-config.js`
-
-```javascript
-{
-  plugins: [
-    `gatsby-plugin-breadcrumb`,
-  ],
-}
-```
-
-`/pages/about-us.js`
-
-```jsx
-import React from 'react'
-import MyCustomBreadcrumb from './my-custom-breadcrumb'
-import { useBreadcrumb } from 'gatsby-plugin-breadcrumb'
-
-export const AboutUs = ({ location }) => {
-  const { crumbs } = useBreadcrumb({
-    location,
-    crumbLabel: 'About Us',
-    crumbSeparator: ' / ',
-  })
-  return (
-    <div>
-      <MyCustomBreadcrumb crumbs={crumbs} />
-      ...
-    </div>
-  )
-}
-```
-
-### `useBreadcrumb` arguments and returns
-
-The `useBreadcrumb` hook takes an object with the following properties:
-
-| prop             | type   | description                                     | examples                                                        | required |
-| ---------------- | ------ | ----------------------------------------------- | --------------------------------------------------------------- | -------- |
-| location         | object | Reach Router location prop                      | See Reach Router location prop, passed by Gatsby to every page. | required |
-| crumbLabel       | string | Name for the breadcrumb                         | `"About Us"`                                                    | required |
-| crumbSeparator   | string | Separator between each breadcrumb               | `" / "`                                                         | optional |
-| crumbStyle       | object | CSS object applied to the current crumb         | `{ color: 'orange' }`                                           | optional |
-| crumbActiveStyle | object | CSS object applied to current crumb when active | `{ color: 'cornflowerblue'}`                                    | optional |
-
-`useBreadcrumb` returns the following:
-
-| value         | type  | description                                               |
-| ------------- | ----- | --------------------------------------------------------- |
-| crumbs        | array | Array of the current breadcrumbs                          |
-| useClassNames | bool  | Value of the useClassNames plugin option (default: false) |
-| useAutoGen    | bool  | Value of the useAutoGen plugin option (default: false)    |
-
-The `useBreadcrumb` hook will determine if it needs to add, remove, or do
-nothing with the breadcrumbs based on the location you pass. You only need to
-pass it the required props (`location`, `crumbLabel`).
-
 ## Gotchas
 
 Here are a few gotchas. If you notice any more you think should be mentioned
@@ -466,5 +472,5 @@ here submit a PR or create an issue.
 - In your `gatsby-config.js` option `siteMetaData.siteUrl` be sure to remove any
   trailing slashes
 
-- The `<Link>'s` throughout your site need to have `to` properties that match
+- The `<Link />'s` throughout your site need to have `to` properties that match
   your breadcrumb `to` properties for activeStyles to be applied.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 Add Breadcrumbs to your Gatsby Site!
 
 - [Installation](https://github.com/sbardian/gatsby-plugin-breadcrumb#installation)
-- [Demo](https://github.com/sbardian/gatsby-plugin-breadcrumb#demo)
 - [Usage](https://github.com/sbardian/gatsby-plugin-breadcrumb#usage)
 - [Gotchas](https://github.com/sbardian/gatsby-plugin-breadcrumb#gotchas)
 
@@ -28,14 +27,10 @@ or
 npm install gatsby-plugin-breadcrumb
 ```
 
-## Demo
-
-CodeSandbox.io [Demo](https://codesandbox.io/s/50o4zwm91l)
-
-# \* Warning: `<SitemapCrumbs />` component has been deprecated and replaced by the `<Breadcrumb />`
+## \* Warning: `<SitemapCrumbs />` component has been deprecated and replaced by the `<Breadcrumb />` component
 
 The `<SitemapCrumbs />` component has been deprecated and will be removed in
-version 6. This will simplify the API so you always use the `<Breadcrumb />`
+version 7. This will simplify the API so you always use the `<Breadcrumb />`
 component, reguardless of the way you are using `gatsby-plugin-breadcrumb`
 (Click Tracking or AutoGen (new Sitemap method)). Please update using the
 `<Breadcrumb />` component if you are currently using the `<SitemapCrumbs />`
@@ -49,8 +44,8 @@ your Gatsby site:
 - `Click Tracking`: Click tracking creates a breadcrumb of out of the path taken
   (clicked) by the user.
 
-  - Add the plugin to your `gatsby-config.js`
-  - Import and use the `<Breadcrumb>` component, passing the required props on
+  - Add the plugin `gatsby-plugin-breadcrumb` to your `gatsby-config.js`
+  - Import and use the `<Breadcrumb />` component, passing the required props on
     pages you wish to see the breadcrumb.
 
     - [Click Tracking example](#click-tracking-example)
@@ -61,11 +56,10 @@ your Gatsby site:
 - `AutoGen` (Auto Generated): AutoGen will generate breadcrumbs for each page
   and inject them into pages `pageContext` prop under the `breadcrumb` property.
 
-  - Add the plugin `gatsby-plugin-remove-trailing-slashes`
-  - Add the plugin `gatsby-plugin-breadcrumb` and define the `useAutoGen` plugin
-    option to `true`
+  - Add the plugin `gatsby-plugin-breadcrumb` to your `gatsby-config.js` and
+    define the `useAutoGen` plugin option to `true`
   - Get `crumbs` array from `breadcrumb` object in `pageContext`
-  - Import and use the `<AutoGenCrumb>` component, passing the required props on
+  - Import and use the `<Breadcrumb />` component, passing the required props on
     pages you wish to see the breadcrumb
 
     - [AutoGen example](#autogen-example)
@@ -83,6 +77,8 @@ your Gatsby site:
 
 ## `Click Tracking` example:
 
+CodeSandbox.io [Demo](https://codesandbox.io/s/50o4zwm91l)
+
 `gatsby-config.js`
 
 ```javascript
@@ -91,7 +87,7 @@ your Gatsby site:
     {
       resolves: `gatsby-plugin-breadcrumb`,
       options: {
-        // optional: To create a defaul crumb
+        // optional: To create a default crumb
         // see Click Tracking default crumb example below
         defaultCrumb: {
           location: {
@@ -104,7 +100,7 @@ your Gatsby site:
           crumbActiveStyle: { color: "orange" },
         },
         // optional: switch to className styling
-        // see Click Tracking useClassNames example below
+        // see `useClassNames example with Click Tracking` below
         useClassNames: true,
       }
     }
@@ -131,7 +127,7 @@ export const AboutUs = ({ location }) => {
 
 ### Breadcrumb component with `Click Tracking`
 
-The `<Breadcrumb>` component provides default breadcrumbs, while also allowing
+The `<Breadcrumb />` component provides default breadcrumbs, while also allowing
 you to customize those breadcrumbs if you wish.
 
 ### Breadcrumb Props with `Click Tracking`
@@ -146,14 +142,16 @@ you to customize those breadcrumbs if you wish.
 | crumbStyle        | object | CSS object applied to the current crumb         | `{ color: 'orange' }`                                           | optional | x                      |
 | crumbActiveStyle  | object | CSS object applied to current crumb when active | `{ color: 'cornflowerblue'}`                                    | optional | x                      |
 
-## Other `Click Tracking` options
+### Other `Click Tracking` options
 
-Instead of adding the `<Breadcrumb>` component to every page, another option
+Instead of adding the `<Breadcrumb />` component to every page, another option
 would be to add it to a layout component.
 
 ### `Click Tracking` Layout component example
 
-`aboutus.js`
+CodeSandbox.io [Demo](https://codesandbox.io/s/breadcrumb-with-layout-ce0rp)
+
+`/pages/aboutus.js`
 
 ```jsx
 import React from 'react'
@@ -169,7 +167,7 @@ export const AboutUs = ({ location }) => {
 }
 ```
 
-`contact.js`
+`/pages/contact.js`
 
 ```jsx
 import React from 'react'
@@ -184,7 +182,7 @@ export const Contact = ({location}) => {
 }
 ```
 
-`layout.js`
+`/components/layout.js`
 
 ```jsx
 import React from 'react'
@@ -206,12 +204,12 @@ export const Layout = ({location, crumbLabel}) => {
 
 ### Click Tracking `defaultCrumb` example
 
-While using the `Click Tracking` option with the `<Breadcrumb>` component, if a
-user goes directly to a page, your breadcrumb will start with that page. You may
-want to always provide a default or `Home` breadcrumb. You can do this by adding
-options to the plugin. We must structure the `default` breadcrumb we provide in
-the plugin options in a way our context is expecting, see below for an example
-using all available options.
+While using the `Click Tracking` option with the `<Breadcrumb />` component, if
+a user goes directly to a page, your breadcrumb will start with that page. You
+may want to always provide a default or `Home` breadcrumb. You can do this by
+adding options to the plugin. We must structure the `default` breadcrumb we
+provide in the plugin options in a way our context is expecting, see below for
+an example using all available options.
 
 ```javascript
   {
@@ -256,7 +254,6 @@ component:
     siteUrl: "http://localhost:8000",
   },
   plugins: [
-    `gatsby-plugin-remove-trailing-slashes`,
     {
       resolve: `gatsby-plugin-breadcrumb`,
       options: {
@@ -276,26 +273,15 @@ component:
 
 ## `AutoGen` example
 
+Codesandbox.io [Demo](https://codesandbox.io/s/auto-generated-breadcrumbs-m5p5t)
+
 `AutoGen` (Auto Generated, previously `Sitemap`) used to rely on
 `gatsby-plugin-sitemap`, which creates a sitmap XML file in the `/public` folder
 of your site at the end of the site build. This caused problems when deploying
 to services like Netlify, as the XML file was not created when we needed to try
 to read from it, causing the build to fail. Now `AutoGen` generates the
-breadcrumbs as pages are created.
-
-Install `gatsby-plugin-remove-trailing-slashes`
-
-npm
-
-```bash
-npm install gatsby-plugin-remove-trailing-slashes
-```
-
-yarn
-
-```bash
-yarn add gatsby-plugin-remove-trailing-slashes
-```
+breadcrumbs as pages are created. We also no longer require the
+`gatsby-plugin-remove-trailing-slashes` plugin.
 
 Add the following to your gatsby-config
 
@@ -308,7 +294,6 @@ Add the following to your gatsby-config
     siteUrl: "http://localhost:8000",
   },
   plugins: [
-    `gatsby-plugin-remove-trailing-slashes`,
     {
       resolve: `gatsby-plugin-breadcrumb`,
       options: {
@@ -316,7 +301,7 @@ Add the following to your gatsby-config
         useAutoGen: true,
         // autoGenHomeLabel: optional 'Home' is default
         autoGenHomeLabel: `Root`,
-        // exlude: optional, include to overwrite default excluded pages
+        // exlude: optional, include to overwrite these default excluded pages
         exclude: [
           `/dev-404-page`,
           `/404`,
@@ -324,7 +309,7 @@ Add the following to your gatsby-config
           `/offline-plugin-app-shell-fallback`,
         ],
         // optional: switch to className styling
-        // see AutoGenCrumb useClassNames example below
+        // see `useClassNames example with `AutoGen` below
         useClassNames: true,
      },
   ]
@@ -405,7 +390,6 @@ component:
     siteUrl: "http://localhost:8000",
   },
   plugins: [
-    `gatsby-plugin-remove-trailing-slashes`,
     {
       resolve: `gatsby-plugin-breadcrumb`,
       options: {
@@ -428,7 +412,7 @@ component:
 }
 ```
 
-`/pages/home.js`
+`/pages/about-us.js`
 
 ```jsx
 import React from 'react'
@@ -450,9 +434,9 @@ export const AboutUs = ({ location }) => {
 }
 ```
 
-### `useBreadcrumb` props and returns
+### `useBreadcrumb` arguments and returns
 
-The `useBreadcrumb` hook takes an object with the following props:
+The `useBreadcrumb` hook takes an object with the following properties:
 
 | prop             | type   | description                                     | examples                                                        | required |
 | ---------------- | ------ | ----------------------------------------------- | --------------------------------------------------------------- | -------- |
@@ -464,10 +448,12 @@ The `useBreadcrumb` hook takes an object with the following props:
 
 `useBreadcrumb` returns the following:
 
-| value        | type     | description                                                                                                             |
-| ------------ | -------- | ----------------------------------------------------------------------------------------------------------------------- |
-| crumbs       | array    | Array of the current breadcrumbs                                                                                        |
-| updateCrumbs | function | function to enable you to manually update crumbs (The hook should handle this, only use if you know what you are doing) |
+| value         | type     | description                                                                                                             |
+| ------------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| crumbs        | array    | Array of the current breadcrumbs                                                                                        |
+| updateCrumbs  | function | Function to enable you to manually update crumbs (The hook should handle this, only use if you know what you are doing) |
+| useClassNames | bool     | Value of the useClassNames plugin option (default: false)                                                               |
+| useAutoGen    | bool     | Value of the useAutoGen plugin option (default: false)                                                                  |
 
 The `useBreadcrumb` hook will determine if it needs to add, remove, or do
 nothing with the breadcrumbs based on the location you pass. You only need to
@@ -475,8 +461,8 @@ pass it the required props (`location`, `crumbLabel`).
 
 ## Gotchas
 
-Here are a few gotchas we have noticed. If you notice any more you think should
-be mentioned here submit a PR, or just let us know!
+Here are a few gotchas. If you notice any more you think should be mentioned
+here submit a PR or create an issue.
 
 - In your `gatsby-config.js` option `siteMetaData.siteUrl` be sure to remove any
   trailing slashes

--- a/src/components/Breadcrumb.js
+++ b/src/components/Breadcrumb.js
@@ -1,102 +1,19 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable react/no-array-index-key */
 import React from 'react'
-import Proptypes from 'prop-types'
-import { Link } from 'gatsby'
+import AutoGenCrumb from './auto-gen-crumb'
+import ClickTrackingCrumb from './click-tracking-crumb'
 import useBreadcrumb from './useBreadcrumb'
 
-const Breadcrumb = ({
-  title,
-  location,
-  crumbLabel,
-  crumbSeparator,
-  crumbWrapperStyle,
-  crumbActiveStyle,
-  crumbStyle,
-  ...rest
-}) => {
-  const { crumbs = [], useClassNames } = useBreadcrumb({
-    location,
-    crumbLabel,
-    crumbSeparator,
-    crumbStyle,
-    crumbActiveStyle,
-  })
+const Breadcrumb = props => {
+  const { useAutoGen } = useBreadcrumb({})
 
   return (
-    <div>
-      <span className="breadcrumb__title">{title}</span>
-      {crumbs.map((c, i) => {
-        return (
-          <div
-            className="breadcrumb"
-            style={
-              useClassNames ? null : { display: 'inline', ...crumbWrapperStyle }
-            }
-            key={i}
-          >
-            <Link
-              to={c.pathname || ''}
-              style={
-                useClassNames
-                  ? null
-                  : {
-                      textDecoration: 'none',
-                      fontSize: '16pt',
-                      color: '#e1e1e1',
-                      ...c.crumbStyle,
-                    }
-              }
-              activeStyle={
-                useClassNames
-                  ? null
-                  : {
-                      color: 'white',
-                      ...crumbActiveStyle,
-                    }
-              }
-              state={{
-                crumbClicked: true,
-              }}
-              className="breadcrumb__link"
-              activeClassName={
-                useClassNames ? 'breadcrumb__link__active' : null
-              }
-              {...rest}
-            >
-              {c.crumbLabel}
-            </Link>
-            <span
-              className="breadcrumb__separator"
-              style={
-                useClassNames ? null : { fontSize: '16pt', ...c.crumbStyle }
-              }
-            >
-              {i === crumbs.length - 1 ? null : c.crumbSeparator}
-            </span>
-          </div>
-        )
-      })}
-    </div>
+    <>
+      {useAutoGen && <AutoGenCrumb {...props} />}
+      {!useAutoGen && <ClickTrackingCrumb {...props} />}
+    </>
   )
-}
-
-Breadcrumb.defaultProps = {
-  title: '',
-  crumbSeparator: ' / ',
-  crumbWrapperStyle: {},
-  crumbStyle: {},
-  crumbActiveStyle: {},
-}
-
-Breadcrumb.propTypes = {
-  location: Proptypes.shape().isRequired,
-  crumbLabel: Proptypes.string.isRequired,
-  title: Proptypes.string,
-  crumbSeparator: Proptypes.string,
-  crumbWrapperStyle: Proptypes.shape(),
-  crumbActiveStyle: Proptypes.shape(),
-  crumbStyle: Proptypes.shape(),
 }
 
 export default Breadcrumb

--- a/src/components/Breadcrumb.js
+++ b/src/components/Breadcrumb.js
@@ -3,10 +3,10 @@
 import React from 'react'
 import AutoGenCrumb from './auto-gen-crumb'
 import ClickTrackingCrumb from './click-tracking-crumb'
-import useBreadcrumb from './useBreadcrumb'
+import { OptionsContext } from './options-context'
 
 const Breadcrumb = props => {
-  const { useAutoGen } = useBreadcrumb({})
+  const { useAutoGen } = React.useContext(OptionsContext)
 
   return (
     <>

--- a/src/components/BreadcrumbContext.js
+++ b/src/components/BreadcrumbContext.js
@@ -6,8 +6,9 @@ export const BreadcrumbContext = React.createContext('Breadcrumb')
 
 export const BreadcrumbProvider = ({
   children,
-  setHome = {},
+  setHome = null,
   useClassNames = false,
+  useAutoGen = false,
 }) => {
   let defaultCrumb = {}
   if (setHome) {
@@ -57,6 +58,7 @@ export const BreadcrumbProvider = ({
     crumbs,
     updateCrumbs,
     useClassNames,
+    useAutoGen,
   }
 
   return (
@@ -71,6 +73,7 @@ export const BreadcrumbConsumer = BreadcrumbContext.Consumer
 BreadcrumbProvider.defaultProps = {
   setHome: {},
   useClassNames: false,
+  useAutoGen: false,
 }
 
 BreadcrumbProvider.propTypes = {
@@ -88,4 +91,5 @@ BreadcrumbProvider.propTypes = {
     crumbActiveStyle: PropTypes.shape(),
   }),
   useClassNames: PropTypes.bool,
+  useAutoGen: PropTypes.bool,
 }

--- a/src/components/BreadcrumbContext.js
+++ b/src/components/BreadcrumbContext.js
@@ -4,12 +4,7 @@ import PropTypes from 'prop-types'
 
 export const BreadcrumbContext = React.createContext('Breadcrumb')
 
-export const BreadcrumbProvider = ({
-  children,
-  setHome = null,
-  useClassNames = false,
-  useAutoGen = false,
-}) => {
+export const BreadcrumbProvider = ({ children, setHome = null }) => {
   let defaultCrumb = {}
   if (setHome) {
     defaultCrumb = {
@@ -57,8 +52,6 @@ export const BreadcrumbProvider = ({
   const crumb = {
     crumbs,
     updateCrumbs,
-    useClassNames,
-    useAutoGen,
   }
 
   return (
@@ -72,8 +65,6 @@ export const BreadcrumbConsumer = BreadcrumbContext.Consumer
 
 BreadcrumbProvider.defaultProps = {
   setHome: {},
-  useClassNames: false,
-  useAutoGen: false,
 }
 
 BreadcrumbProvider.propTypes = {
@@ -90,6 +81,4 @@ BreadcrumbProvider.propTypes = {
     crumbStyle: PropTypes.shape(),
     crumbActiveStyle: PropTypes.shape(),
   }),
-  useClassNames: PropTypes.bool,
-  useAutoGen: PropTypes.bool,
 }

--- a/src/components/auto-gen-crumb.js
+++ b/src/components/auto-gen-crumb.js
@@ -3,7 +3,7 @@
 import React from 'react'
 import Proptypes from 'prop-types'
 import { Link } from 'gatsby'
-import useBreadcrumb from './useBreadcrumb'
+import { OptionsContext } from './options-context'
 
 const AutoGenCrumb = ({
   title = '',
@@ -15,7 +15,8 @@ const AutoGenCrumb = ({
   crumbLabel: crumbLabelOverride = null,
   ...rest
 }) => {
-  const { useClassNames } = useBreadcrumb({})
+  const { useClassNames } = React.useContext(OptionsContext)
+
   return (
     <div>
       <span>{title}</span>
@@ -78,7 +79,6 @@ AutoGenCrumb.defaultProps = {
   crumbStyle: {},
   crumbActiveStyle: {},
   crumbLabel: null,
-  useClassNames: false,
 }
 
 AutoGenCrumb.propTypes = {
@@ -94,7 +94,6 @@ AutoGenCrumb.propTypes = {
     }),
   ).isRequired,
   crumbLabel: Proptypes.string,
-  useClassNames: Proptypes.bool,
 }
 
 export default AutoGenCrumb

--- a/src/components/auto-gen-crumb.js
+++ b/src/components/auto-gen-crumb.js
@@ -1,0 +1,100 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable react/no-array-index-key */
+import React from 'react'
+import Proptypes from 'prop-types'
+import { Link } from 'gatsby'
+import useBreadcrumb from './useBreadcrumb'
+
+const AutoGenCrumb = ({
+  title = '',
+  crumbSeparator,
+  crumbWrapperStyle,
+  crumbActiveStyle,
+  crumbStyle,
+  crumbs: autoGenCrumbs,
+  crumbLabel: crumbLabelOverride = null,
+  ...rest
+}) => {
+  const { useClassNames } = useBreadcrumb({})
+  return (
+    <div>
+      <span>{title}</span>
+      {autoGenCrumbs.map((c, i) => {
+        return (
+          <div
+            className="breadcrumb"
+            style={
+              useClassNames ? null : { display: 'inline', ...crumbWrapperStyle }
+            }
+            key={i}
+          >
+            <Link
+              to={c.pathname}
+              style={
+                useClassNames
+                  ? null
+                  : {
+                      textDecoration: 'none',
+                      fontSize: '16pt',
+                      color: '#e1e1e1',
+                      ...crumbStyle,
+                    }
+              }
+              activeStyle={
+                useClassNames
+                  ? null
+                  : {
+                      color: 'white',
+                      ...crumbActiveStyle,
+                    }
+              }
+              className="breadcrumb__link"
+              activeClassName={
+                useClassNames ? 'breadcrumb__link__active' : null
+              }
+              {...rest}
+            >
+              {crumbLabelOverride && i === autoGenCrumbs.length - 1
+                ? crumbLabelOverride
+                : c.crumbLabel}
+            </Link>
+            <span
+              className="breadcrumb__separator"
+              style={useClassNames ? null : { fontSize: '16pt', ...crumbStyle }}
+            >
+              {i === autoGenCrumbs.length - 1 ? null : crumbSeparator}
+            </span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+AutoGenCrumb.defaultProps = {
+  title: '',
+  crumbSeparator: ' / ',
+  crumbWrapperStyle: {},
+  crumbStyle: {},
+  crumbActiveStyle: {},
+  crumbLabel: null,
+  useClassNames: false,
+}
+
+AutoGenCrumb.propTypes = {
+  title: Proptypes.string,
+  crumbSeparator: Proptypes.string,
+  crumbWrapperStyle: Proptypes.shape(),
+  crumbActiveStyle: Proptypes.shape(),
+  crumbStyle: Proptypes.shape(),
+  crumbs: Proptypes.arrayOf(
+    Proptypes.shape({
+      location: Proptypes.shape(),
+      pathname: Proptypes.string.isRequired,
+    }),
+  ).isRequired,
+  crumbLabel: Proptypes.string,
+  useClassNames: Proptypes.bool,
+}
+
+export default AutoGenCrumb

--- a/src/components/click-tracking-crumb.js
+++ b/src/components/click-tracking-crumb.js
@@ -5,6 +5,8 @@ import Proptypes from 'prop-types'
 import { Link } from 'gatsby'
 import useBreadcrumb from './useBreadcrumb'
 
+// TODO: Delete before v7 release
+
 const ClickTrackingCrumb = ({
   title,
   location,

--- a/src/components/click-tracking-crumb.js
+++ b/src/components/click-tracking-crumb.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import Proptypes from 'prop-types'
 import { Link } from 'gatsby'
+import { OptionsContext } from './options-context'
 import useBreadcrumb from './useBreadcrumb'
 
 // TODO: Delete before v7 release
@@ -17,13 +18,15 @@ const ClickTrackingCrumb = ({
   crumbStyle,
   ...rest
 }) => {
-  const { crumbs = [], useClassNames } = useBreadcrumb({
+  const { crumbs = [] } = useBreadcrumb({
     location,
     crumbLabel,
     crumbSeparator,
     crumbStyle,
     crumbActiveStyle,
   })
+
+  const { useClassNames } = React.useContext(OptionsContext)
 
   return (
     <div>

--- a/src/components/click-tracking-crumb.js
+++ b/src/components/click-tracking-crumb.js
@@ -5,21 +5,28 @@ import Proptypes from 'prop-types'
 import { Link } from 'gatsby'
 import useBreadcrumb from './useBreadcrumb'
 
-const SitemapCrumb = ({
-  title = '',
+const ClickTrackingCrumb = ({
+  title,
+  location,
+  crumbLabel,
   crumbSeparator,
   crumbWrapperStyle,
   crumbActiveStyle,
   crumbStyle,
-  crumbs: siteCrumbs,
-  crumbLabel: crumbLabelOverride = null,
   ...rest
 }) => {
-  const { useClassNames } = useBreadcrumb({})
+  const { crumbs = [], useClassNames } = useBreadcrumb({
+    location,
+    crumbLabel,
+    crumbSeparator,
+    crumbStyle,
+    crumbActiveStyle,
+  })
+
   return (
     <div>
-      <span>{title}</span>
-      {siteCrumbs.map((c, i) => {
+      <span className="breadcrumb__title">{title}</span>
+      {crumbs.map((c, i) => {
         return (
           <div
             className="breadcrumb"
@@ -29,7 +36,7 @@ const SitemapCrumb = ({
             key={i}
           >
             <Link
-              to={c.pathname}
+              to={c.pathname || ''}
               style={
                 useClassNames
                   ? null
@@ -37,7 +44,7 @@ const SitemapCrumb = ({
                       textDecoration: 'none',
                       fontSize: '16pt',
                       color: '#e1e1e1',
-                      ...crumbStyle,
+                      ...c.crumbStyle,
                     }
               }
               activeStyle={
@@ -48,21 +55,24 @@ const SitemapCrumb = ({
                       ...crumbActiveStyle,
                     }
               }
+              state={{
+                crumbClicked: true,
+              }}
               className="breadcrumb__link"
               activeClassName={
                 useClassNames ? 'breadcrumb__link__active' : null
               }
               {...rest}
             >
-              {crumbLabelOverride && i === siteCrumbs.length - 1
-                ? crumbLabelOverride
-                : c.crumbLabel}
+              {c.crumbLabel}
             </Link>
             <span
               className="breadcrumb__separator"
-              style={useClassNames ? null : { fontSize: '16pt', ...crumbStyle }}
+              style={
+                useClassNames ? null : { fontSize: '16pt', ...c.crumbStyle }
+              }
             >
-              {i === siteCrumbs.length - 1 ? null : crumbSeparator}
+              {i === crumbs.length - 1 ? null : c.crumbSeparator}
             </span>
           </div>
         )
@@ -71,28 +81,22 @@ const SitemapCrumb = ({
   )
 }
 
-SitemapCrumb.defaultProps = {
+ClickTrackingCrumb.defaultProps = {
   title: '',
   crumbSeparator: ' / ',
   crumbWrapperStyle: {},
   crumbStyle: {},
   crumbActiveStyle: {},
-  crumbLabel: null,
 }
 
-SitemapCrumb.propTypes = {
+ClickTrackingCrumb.propTypes = {
+  location: Proptypes.shape().isRequired,
+  crumbLabel: Proptypes.string.isRequired,
   title: Proptypes.string,
   crumbSeparator: Proptypes.string,
   crumbWrapperStyle: Proptypes.shape(),
   crumbActiveStyle: Proptypes.shape(),
   crumbStyle: Proptypes.shape(),
-  crumbs: Proptypes.arrayOf(
-    Proptypes.shape({
-      location: Proptypes.shape(),
-      pathname: Proptypes.string.isRequired,
-    }),
-  ).isRequired,
-  crumbLabel: Proptypes.string,
 }
 
-export default SitemapCrumb
+export default ClickTrackingCrumb

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,6 +1,6 @@
 import Breadcrumb from './Breadcrumb'
 import AutoGenCrumb from './auto-gen-crumb'
-// TODO: remove after next major release
+// TODO: remove before v7 release
 import SitemapCrumbs from './sitemap-crumbs'
 import {
   BreadcrumbContext,
@@ -15,7 +15,7 @@ export {
   BreadcrumbConsumer,
   BreadcrumbProvider,
   useBreadcrumb,
-  // TODO: remove after next major release
+  // TODO: remove before v7 release
   SitemapCrumbs,
   AutoGenCrumb,
 }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,11 +1,13 @@
-import Breadcrumb from './Breadcrumb';
-import SitemapCrumbs from './SitemapCrumbs';
+import Breadcrumb from './Breadcrumb'
+import AutoGenCrumb from './auto-gen-crumb'
+// TODO: remove after next major release
+import SitemapCrumbs from './sitemap-crumbs'
 import {
   BreadcrumbContext,
   BreadcrumbConsumer,
   BreadcrumbProvider,
-} from './BreadcrumbContext';
-import useBreadcrumb from './useBreadcrumb';
+} from './BreadcrumbContext'
+import useBreadcrumb from './useBreadcrumb'
 
 export {
   Breadcrumb,
@@ -13,5 +15,7 @@ export {
   BreadcrumbConsumer,
   BreadcrumbProvider,
   useBreadcrumb,
+  // TODO: remove after next major release
   SitemapCrumbs,
-};
+  AutoGenCrumb,
+}

--- a/src/components/options-context.js
+++ b/src/components/options-context.js
@@ -1,0 +1,35 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export const OptionsContext = React.createContext('Options')
+
+export const OptionsProvider = ({
+  children,
+  useClassNames = false,
+  useAutoGen = false,
+}) => {
+  const options = {
+    useClassNames,
+    useAutoGen,
+  }
+
+  return (
+    <OptionsContext.Provider value={options}>
+      {children}
+    </OptionsContext.Provider>
+  )
+}
+
+export const OptionsConsumer = OptionsContext.Consumer
+
+OptionsProvider.defaultProps = {
+  useClassNames: false,
+  useAutoGen: false,
+}
+
+OptionsProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+  useClassNames: PropTypes.bool,
+  useAutoGen: PropTypes.bool,
+}

--- a/src/components/sitemap-crumbs.js
+++ b/src/components/sitemap-crumbs.js
@@ -1,0 +1,14 @@
+// eslint-disable-next-line
+import React from 'react'
+import AutoGenCrumb from './auto-gen-crumb'
+
+// TODO: delete component after next major release
+const SitemapCrumbs = props => {
+  // eslint-disable-next-line
+  console.warn(
+    `Warning: <SitemapCrumbs /> has been deprecated.  Please update your code to use <Breadcrumb /> component. See docs https://github.com/sbardian/gatsby-plugin-breadcrumb for details.`,
+  )
+  return <AutoGenCrumb {...props} />
+}
+
+export default SitemapCrumbs

--- a/src/components/sitemap-crumbs.js
+++ b/src/components/sitemap-crumbs.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import AutoGenCrumb from './auto-gen-crumb'
 
-// TODO: delete component after next major release
+// TODO: Delete before v7 release
 const SitemapCrumbs = props => {
   // eslint-disable-next-line
   console.warn(

--- a/src/components/useBreadcrumb.js
+++ b/src/components/useBreadcrumb.js
@@ -9,15 +9,11 @@ const useBreadcrumb = ({
   crumbStyle = {},
   crumbActiveStyle = {},
 }) => {
-  const { crumbs, updateCrumbs, useClassNames, useAutoGen } = React.useContext(
-    BreadcrumbContext,
-  )
+  const { crumbs, updateCrumbs } = React.useContext(BreadcrumbContext)
 
   if (!location || !crumbLabel) {
     return {
       crumbs,
-      useClassNames,
-      useAutoGen,
     }
   }
 
@@ -33,8 +29,6 @@ const useBreadcrumb = ({
 
   return {
     crumbs,
-    useClassNames,
-    useAutoGen,
   }
 }
 

--- a/src/components/useBreadcrumb.js
+++ b/src/components/useBreadcrumb.js
@@ -16,7 +16,6 @@ const useBreadcrumb = ({
   if (!location || !crumbLabel) {
     return {
       crumbs,
-      updateCrumbs,
       useClassNames,
       useAutoGen,
     }
@@ -34,7 +33,6 @@ const useBreadcrumb = ({
 
   return {
     crumbs,
-    updateCrumbs,
     useClassNames,
     useAutoGen,
   }

--- a/src/components/useBreadcrumb.js
+++ b/src/components/useBreadcrumb.js
@@ -9,7 +9,7 @@ const useBreadcrumb = ({
   crumbStyle = {},
   crumbActiveStyle = {},
 }) => {
-  const { crumbs, updateCrumbs, useClassNames } = React.useContext(
+  const { crumbs, updateCrumbs, useClassNames, useAutoGen } = React.useContext(
     BreadcrumbContext,
   )
 
@@ -18,6 +18,7 @@ const useBreadcrumb = ({
       crumbs,
       updateCrumbs,
       useClassNames,
+      useAutoGen,
     }
   }
 
@@ -35,6 +36,7 @@ const useBreadcrumb = ({
     crumbs,
     updateCrumbs,
     useClassNames,
+    useAutoGen,
   }
 }
 

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -5,20 +5,15 @@ import React from 'react'
 import { BreadcrumbProvider } from './components/BreadcrumbContext'
 
 export const wrapRootElement = ({ element }, pluginOptions) => {
-  if (
-    (pluginOptions && pluginOptions.defaultCrumb) ||
-    (pluginOptions && pluginOptions.useClassNames)
-  ) {
-    const { defaultCrumb, useClassNames } = pluginOptions
+  const { defaultCrumb, useClassNames, useAutoGen } = pluginOptions
 
-    return (
-      <BreadcrumbProvider
-        setHome={defaultCrumb}
-        useClassNames={useClassNames || false}
-      >
-        {element}
-      </BreadcrumbProvider>
-    )
-  }
-  return <BreadcrumbProvider>{element}</BreadcrumbProvider>
+  return (
+    <BreadcrumbProvider
+      setHome={defaultCrumb || null}
+      useAutoGen={useAutoGen || false}
+      useClassNames={useClassNames || false}
+    >
+      {element}
+    </BreadcrumbProvider>
+  )
 }

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -3,17 +3,19 @@
 /* eslint-disable react/prop-types */
 import React from 'react'
 import { BreadcrumbProvider } from './components/BreadcrumbContext'
+import { OptionsProvider } from './components/options-context'
 
 export const wrapRootElement = ({ element }, pluginOptions) => {
   const { defaultCrumb, useClassNames, useAutoGen } = pluginOptions
 
   return (
-    <BreadcrumbProvider
-      setHome={defaultCrumb || null}
+    <OptionsProvider
       useAutoGen={useAutoGen || false}
       useClassNames={useClassNames || false}
     >
-      {element}
-    </BreadcrumbProvider>
+      <BreadcrumbProvider setHome={defaultCrumb || null}>
+        {element}
+      </BreadcrumbProvider>
+    </OptionsProvider>
   )
 }

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,5 +1,6 @@
 exports.onCreatePage = ({ page, actions }, pluginOptions) => {
-  if (pluginOptions.useSitemap) {
+  // TODO: remove useSitemap after next major release
+  if (pluginOptions.useSitemap || pluginOptions.useAutoGen) {
     const { createPage, deletePage } = actions
 
     const defaultOptions = {
@@ -24,7 +25,11 @@ exports.onCreatePage = ({ page, actions }, pluginOptions) => {
             ...crumbs,
             {
               pathname: '/',
-              crumbLabel: optionsActual.sitemapHomeLabel || 'Home',
+              // TODO: remove sitemapHomeLabel option after next major release
+              crumbLabel:
+                optionsActual.sitemapHomeLabel ||
+                optionsActual.autoGenHomeLabel ||
+                'Home',
             },
           ]
         } else if (index !== 0 && split !== '') {

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,5 +1,5 @@
 exports.onCreatePage = ({ page, actions }, pluginOptions) => {
-  // TODO: remove useSitemap after next major release
+  // TODO: remove useSitemap before v7 release
   if (pluginOptions.useSitemap || pluginOptions.useAutoGen) {
     const { createPage, deletePage } = actions
 
@@ -25,7 +25,7 @@ exports.onCreatePage = ({ page, actions }, pluginOptions) => {
             ...crumbs,
             {
               pathname: '/',
-              // TODO: remove sitemapHomeLabel option after next major release
+              // TODO: remove sitemapHomeLabel option before v7 release
               crumbLabel:
                 optionsActual.sitemapHomeLabel ||
                 optionsActual.autoGenHomeLabel ||

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,10 @@ import {
   BreadcrumbConsumer,
   BreadcrumbProvider,
   useBreadcrumb,
+  // TODO: remove after next major release
   SitemapCrumbs,
-} from './components';
+  AutoGenCrumb,
+} from './components'
 
 export {
   Breadcrumb,
@@ -13,5 +15,7 @@ export {
   BreadcrumbConsumer,
   BreadcrumbProvider,
   useBreadcrumb,
+  // TODO: remove after next major release
   SitemapCrumbs,
-};
+  AutoGenCrumb,
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import {
   BreadcrumbConsumer,
   BreadcrumbProvider,
   useBreadcrumb,
-  // TODO: remove after next major release
+  // TODO: remove before v7 release
   SitemapCrumbs,
   AutoGenCrumb,
 } from './components'
@@ -15,7 +15,7 @@ export {
   BreadcrumbConsumer,
   BreadcrumbProvider,
   useBreadcrumb,
-  // TODO: remove after next major release
+  // TODO: remove before v7 release
   SitemapCrumbs,
   AutoGenCrumb,
 }


### PR DESCRIPTION
BREAKING CHANGES: 
- Deprecate `<SitemapCrumbs />` component
- useBreadcrumb no longer returns `updateCrumbs` function

OTHER CHANGES: 
- README updates
