### PR TITLE
fix(auto-gen-crumbs): add class name and update README for title

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ you to customize those breadcrumbs if you wish.
 | ----------------- | ------ | ----------------------------------------------- | --------------------------------------------------------------- | -------- | ---------------------- |
 | location          | object | Reach Router location prop                      | See Reach Router location prop, passed by Gatsby to every page. | required |                        |
 | crumbLabel        | string | Name for the breadcrumb                         | `"About Us"`                                                    | required |                        |
-| title             | string | Title proceeding the breadcrumbs                | `"Breadcrumbs: "`, `">>>"`                                      | optional |                        |
+| title             | string | Title preceding the breadcrumbs                | `"Breadcrumbs: "`, `">>>"`                                      | optional |                        |
 | crumbSeparator    | string | Separator between each breadcrumb               | `" / "`                                                         | optional |                        |
 | crumbWrapperStyle | object | CSS object applied to breadcrumb wrapper        | `{ border: '1px solid white' }`                                 | optional | x                      |
 | crumbStyle        | object | CSS object applied to the current crumb         | `{ color: 'orange' }`                                           | optional | x                      |
@@ -427,7 +427,7 @@ of to individual crumbs, as with Click Tracking.
 | prop              | type   | description                                   | examples                        | required | useClassNames disables |
 | ----------------- | ------ | --------------------------------------------- | ------------------------------- | -------- | ---------------------- |
 | crumbs            | array  | Array of crumbs return from pageContext       | n/a                             | required |                        |
-| title             | string | Title proceeding the breadcrumbs              | `"Breadcrumbs: "`, `">>>"`      | optional |                        |
+| title             | string | Title preceding the breadcrumbs              | `"Breadcrumbs: "`, `">>>"`      | optional |                        |
 | crumbSeparator    | string | Separator between each breadcrumb             | `" / "`                         | optional |                        |
 | crumbLabel        | string | Override crumb label from xml path            | `"About Us"`                    | optional |                        |
 | crumbWrapperStyle | object | CSS object applied to breadcrumb wrapper      | `{ border: '1px solid white' }` | optional | x                      |

--- a/src/components/auto-gen-crumb.js
+++ b/src/components/auto-gen-crumb.js
@@ -21,7 +21,7 @@ const AutoGenCrumb = ({
 
   return (
     <div>
-      <span>{title}</span>
+      <span className="breadcrumb__title">{title}</span>
       {autoGenCrumbs.map((c, i) => {
         if (hiddenCrumbs.includes(c.pathname)) {
           return null


### PR DESCRIPTION
- Changed `proceeding` (which implies afterwards) to `preceding` which is more suitable for the title which comes before.

- Added missing class `breadcrumb__title` on title in the auto gen component.