### PR TITLE
Patch 1

### DIFF
--- a/src/components/auto-gen-crumb.js
+++ b/src/components/auto-gen-crumb.js
@@ -74,7 +74,7 @@ AutoGenCrumb.defaultProps = {
 
 AutoGenCrumb.propTypes = {
   title: Proptypes.string,
-  crumbSeparator: Proptypes.oneOfType([Proptypes.string, Proptypes.object]),
+  crumbSeparator: Proptypes.oneOfType([Proptypes.string, Proptypes.element]),
   crumbs: Proptypes.arrayOf(
     Proptypes.shape({
       location: Proptypes.shape(),

--- a/src/components/auto-gen-crumb.js
+++ b/src/components/auto-gen-crumb.js
@@ -74,7 +74,7 @@ AutoGenCrumb.defaultProps = {
 
 AutoGenCrumb.propTypes = {
   title: Proptypes.string,
-  crumbSeparator: _propTypes.default.oneOfType([_propTypes.default.string, _propTypes.default.object]),
+  crumbSeparator: Proptypes.oneOfType([Proptypes.string, Proptypes.object]),
   crumbs: Proptypes.arrayOf(
     Proptypes.shape({
       location: Proptypes.shape(),

--- a/src/components/auto-gen-crumb.js
+++ b/src/components/auto-gen-crumb.js
@@ -74,7 +74,7 @@ AutoGenCrumb.defaultProps = {
 
 AutoGenCrumb.propTypes = {
   title: Proptypes.string,
-  crumbSeparator: Proptypes.string,
+  crumbSeparator: _propTypes.default.oneOfType([_propTypes.default.string, _propTypes.default.object]),
   crumbs: Proptypes.arrayOf(
     Proptypes.shape({
       location: Proptypes.shape(),


### PR DESCRIPTION
Let PropTypes validate using, for expample, a <i> element as a breadcrumb. By the way, is now working, but Proptypes is sending a warning.