### PR TITLE
fix: Set correct gatsby peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
     "semantic-release": "17.4.2"
   },
   "peerDependencies": {
-    "gatsby": ">=3.1.0"
+    "gatsby": "^3.0.0"
   }
 }


### PR DESCRIPTION
Hello @sbardian, Gatsby maintainer here 👋 
First and foremost, thanks for creating the plugin & maintaining it. Much appreciated!

While looking at your plugin I noticed that the `peerDependency` on `gatsby` is set incorrectly. We're in the process of providing more helpful information on the `/plugins` page of our website and for that we need plugins to set their `peerDependencies` correctly/more specific.

At the moment you say that _any_ version (v3, v4, v5, v6, etc.) will work with this even when in between we'd introduce breaking changes.

Making it more explicit is the safer choice (in the future you'll be able to mark breaking changes with explicit version ranges) and will allow us to display the plugin as compatible to versions X, Y, Z.

You changed `3.1.0` to `>=3.1.0` in a previous commit which fixed the issue but the current semver range wouldn't allow version `3.0.0` for example. So `^3.0.0` is the better choice here. You can use https://semver.npmjs.com/ to experiment with those things :)

Thanks!